### PR TITLE
Verify .freshbuild directory exists

### DIFF
--- a/Source/Public/Initialize-FreshBuild.ps1
+++ b/Source/Public/Initialize-FreshBuild.ps1
@@ -6,7 +6,12 @@ function Initialize-FreshBuild {
         [switch]$InstallScoop = $false
     )
 
-    $jsonFile = "$env:USERPROFILE/.freshbuild/PackageManagers.json"
+    $freshbuildDir = Join-Path $Env:USERPROFILE ".freshbuild"
+    $jsonFile = Join-Path $FreshBuildDir "PackageManagers.json"
+    
+    if (!(Test-Path $freshbuildDir)) {
+        $null = New-Item -Path $freshbuildDir -ItemType Directory -Force
+    }
 
     if (Test-Path $jsonFile) {
         [string[]]$installed = Get-Content $jsonFile | ConvertFrom-Json;


### PR DESCRIPTION
Hi!

When the script attempts $json | Out-File at the end, it fails with the error:

```
    Out-File: Could not find a part of the path 'C:\Users\MyUsername\.freshbuild\PackageManagers.json'.
```

[Caveat: only tested with Powershell 7.2.0-preview6; I presume the issue occurs with non-preview builds.]
This proposal uses Test-Path and creates the ".freshbuild" directory if needed.